### PR TITLE
feat: expose --skip-schema-update CLI flag for migration commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ clicksuite <command> [options]
 *   `--non-interactive`, `-y`: Run in non-interactive mode, automatically confirming prompts (e.g., for `migrate:reset`). Useful for CI environments.
 *   `--verbose`: Show detailed SQL logs and verbose output. By default, only migration names and results are shown.
 *   `--dry-run`: Preview migrations without executing them (available for `migrate:up` and `migrate:down`). Shows exactly what would be executed.
+*   `--skip-schema-update`: Skip regenerating `schema.sql` after the migration runs (available for `migrate`, `migrate:up`, `migrate:down`, and `migrate:reset`). Useful in CI, where the dump is unused and the full-database `SHOW CREATE` walk can be slow on large/multi-database clusters. Equivalent to the programmatic `skipSchemaUpdate: true` context option.
 
 ### Commands
 
@@ -124,6 +125,7 @@ clicksuite <command> [options]
 
 *   **`clicksuite migrate`**
     *   Runs all pending migrations for the current environment. Equivalent to `clicksuite migrate:up`.
+    *   Use `--skip-schema-update` to skip regenerating `schema.sql` afterwards: `clicksuite migrate --skip-schema-update`
 
 *   **`clicksuite migrate:up [migrationVersion]`**
     *   Applies migrations for the current environment.
@@ -132,6 +134,7 @@ clicksuite <command> [options]
     *   Example: `clicksuite migrate:up 20230101120000`
     *   Use `--dry-run` to preview without executing: `clicksuite migrate:up --dry-run`
     *   Use `--verbose` to see detailed SQL logs: `clicksuite migrate:up --verbose`
+    *   Use `--skip-schema-update` to skip regenerating `schema.sql` afterwards: `clicksuite migrate:up --skip-schema-update`
 
 *   **`clicksuite migrate:down [migrationVersion]`**
     *   Rolls back migrations for the current environment.
@@ -141,6 +144,7 @@ clicksuite <command> [options]
     *   Example (roll back to version): `clicksuite migrate:down 20230101120000`
     *   Use `--dry-run` to preview without executing: `clicksuite migrate:down --dry-run`
     *   Use `--verbose` to see detailed SQL logs: `clicksuite migrate:down --verbose`
+    *   Use `--skip-schema-update` to skip regenerating `schema.sql` afterwards: `clicksuite migrate:down --skip-schema-update`
 
 *   **`clicksuite migrate:reset`**
     *   Rolls back **all** applied migrations for the current environment by executing their `downSQL`.
@@ -554,6 +558,15 @@ The `Context` interface supports all CLI options plus programmatic-specific sett
 By default, Clicksuite automatically generates a `schema.sql` file containing all database objects (tables, views, dictionaries) from **all databases** (excluding system databases) after successful migrations. This provides a complete snapshot of your database schema.
 
 **To disable schema.sql generation:**
+
+From the CLI, pass `--skip-schema-update` to any of `migrate`, `migrate:up`, `migrate:down`, or `migrate:reset`:
+
+```bash
+clicksuite migrate --skip-schema-update
+clicksuite migrate:up --skip-schema-update --non-interactive
+```
+
+Programmatically:
 
 ```typescript
 // Programmatic usage

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,15 @@ import { getContext } from './index';
 // Load environment variables from .env file for CLI usage
 dotenv.config();
 
+// Shared option for the commands that regenerate schema.sql (migrate, migrate:up,
+// migrate:down, migrate:reset). Declared per-command — like --dry-run — so it lands
+// in the handler's parsed argv and flows through getContext into the Runner context.
+const SKIP_SCHEMA_UPDATE_OPTION = {
+  describe: 'Skip regenerating schema.sql after the migration runs (useful in CI, where the dump is unused and can be slow on large databases)',
+  type: 'boolean' as const,
+  default: false,
+};
+
 export function createCli(): Argv {
   return yargs(hideBin(process.argv))
   .option('non-interactive', {
@@ -85,6 +94,9 @@ export function createCli(): Argv {
   .command(
     'migrate',
     'Run all pending migrations (equivalent to migrate:up)',
+    (yargsInstance) => {
+      return yargsInstance.option('skip-schema-update', SKIP_SCHEMA_UPDATE_OPTION);
+    },
     async (argv) => {
       const context = getContext(argv);
       const runner = new Runner(context);
@@ -110,7 +122,8 @@ export function createCli(): Argv {
           describe: 'Preview migrations without executing them',
           type: 'boolean',
           default: false,
-        });
+        })
+        .option('skip-schema-update', SKIP_SCHEMA_UPDATE_OPTION);
     },
     async (argv) => {
       const context = getContext(argv);
@@ -137,7 +150,8 @@ export function createCli(): Argv {
           describe: 'Preview rollbacks without executing them',
           type: 'boolean',
           default: false,
-        });
+        })
+        .option('skip-schema-update', SKIP_SCHEMA_UPDATE_OPTION);
     },
     async (argv) => {
       const context = getContext(argv);
@@ -154,6 +168,9 @@ export function createCli(): Argv {
   .command(
     'migrate:reset',
     'Roll back all applied migrations and clear the migrations table (requires confirmation)',
+    (yargsInstance) => {
+      return yargsInstance.option('skip-schema-update', SKIP_SCHEMA_UPDATE_OPTION);
+    },
     async (argv) => {
       const context = getContext(argv);
       const runner = new Runner(context);

--- a/tests/cli.commands.test.ts
+++ b/tests/cli.commands.test.ts
@@ -119,6 +119,31 @@ describe('CLI commands (cli.ts)', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
     exitSpy.mockRestore();
   });
+
+  // --skip-schema-update is accepted on every command that regenerates schema.sql
+  // and flows through getContext into the Runner's context.
+  it.each([
+    ['migrate', ['migrate']],
+    ['migrate:up', ['migrate:up']],
+    ['migrate:down', ['migrate:down']],
+    ['migrate:reset', ['migrate:reset']],
+  ])('passes --skip-schema-update through to the Runner context for %s', async (_label, cmd) => {
+    process.argv = ['node', 'cli', ...cmd, '--skip-schema-update', '--non-interactive'];
+    const { createCli } = require('../src/cli');
+    await createCli().parseAsync();
+
+    const context = (Runner as unknown as jest.MockedClass<typeof Runner>).mock.calls[0][0];
+    expect(context.skipSchemaUpdate).toBe(true);
+  });
+
+  it('defaults skipSchemaUpdate to false when the flag is omitted', async () => {
+    process.argv = ['node', 'cli', 'migrate', '--non-interactive'];
+    const { createCli } = require('../src/cli');
+    await createCli().parseAsync();
+
+    const context = (Runner as unknown as jest.MockedClass<typeof Runner>).mock.calls[0][0];
+    expect(context.skipSchemaUpdate).toBe(false);
+  });
 });
 
 


### PR DESCRIPTION
## Summary

Exposes the existing `skipSchemaUpdate` capability as a CLI flag. The plumbing is already in place — `Context.skipSchemaUpdate`, `getContext()` reading `argv.skipSchemaUpdate`, and `Runner.up/down/reset` gating the `schema.sql` regeneration on it — but there was no way to set it from the command line. Because the option was never declared, `.strict()` mode rejected `--skip-schema-update` as an unknown argument, so the feature was only reachable via programmatic usage.

This adds `--skip-schema-update` to the four commands that regenerate `schema.sql`: `migrate`, `migrate:up`, `migrate:down`, and `migrate:reset` — following the same per-command pattern already used for `--dry-run`.

## Motivation

After a successful migration, Clicksuite regenerates `schema.sql` by walking `system.tables` across every non-system database and issuing a `SHOW CREATE` per table, materialized view, and dictionary. In a CI pipeline that applies migrations across many databases sequentially (e.g. one per tenant), that dump dominates wall-clock time — and the resulting `schema.sql` is never consumed in CI. `--skip-schema-update` lets a CI invocation opt out of the dump without dropping down to the programmatic API.

The README already lists "Dry run mode" and documents `skipSchemaUpdate` for programmatic use; this just makes the same capability available to CLI users.

## A note on `migrate` and `migrate:reset`

These two commands were using the 3-argument `.command(cmd, desc, asyncFn)` form. In that form yargs treats the function as the **builder** (which receives the yargs instance), not the handler (which receives parsed `argv`). They happened to work because their side effects run inside that function and `getContext` falls back to environment variables — but parsed CLI options never actually reached them. I converted both to the explicit `(builder, handler)` form so the new option (and the existing global flags like `--verbose` / `--non-interactive`) flow through `getContext` as intended. `migrate:up` and `migrate:down` were already using the correct form.

## Changes

- `src/cli.ts` — add `--skip-schema-update` (shared option spec) to the builders of `migrate`, `migrate:up`, `migrate:down`, `migrate:reset`; convert `migrate` and `migrate:reset` to the builder+handler form.
- `tests/cli.commands.test.ts` — assert the flag reaches the `Runner` context for all four commands, and defaults to `false` when omitted.
- `README.md` — document the flag under Global Options, the relevant commands, and the Schema.sql Generation Control section.

## Testing

```
npm run build   # tsc clean
npm test        # 241 passed, 9 suites
```

New cases:
- `passes --skip-schema-update through to the Runner context for migrate` (and `migrate:up` / `migrate:down` / `migrate:reset`)
- `defaults skipSchemaUpdate to false when the flag is omitted`

## Usage

```bash
clicksuite migrate --skip-schema-update
clicksuite migrate:up --skip-schema-update --non-interactive
```